### PR TITLE
Upstream issue #11961: alternative de-duplication approach

### DIFF
--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -345,8 +345,7 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      const [docName, _title, anchor, descr, _score, filename] = result;
-      const resultStr = `${docName},${anchor},${descr},${filename}`;
+      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -343,12 +343,14 @@ const Search = {
 
     // remove duplicate search results
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
+    // this may remove some entries which refer to slightly different parts of the same document
+    // but this is a tradeoff to avoid showing the same document multiple times (the preview always looks the
+    // same, so this is not very useful)
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
-      if (!seen.has(resultStr)) {
+      if (!seen.has(result[0])) {
         acc.push(result);
-        seen.add(resultStr);
+        seen.add(result[0]);
       }
       return acc;
     }, []);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -489,9 +489,11 @@ const Search = {
 
       // create the mapping
       files.forEach((file) => {
-        if (fileMap.has(file) && fileMap.get(file).indexOf(word) === -1)
-          fileMap.get(file).push(word);
-        else fileMap.set(file, [word]);
+        if (!fileMap.has(file)) {
+          fileMap.set(file, [word]);
+        } else if (fileMap.get(file).indexOf(word) === -1) {
+           fileMap.get(file).push(word);
+        }
       });
     });
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -112,7 +112,7 @@ const _finishSearch = (resultCount) => {
       `Search finished, found ${resultCount} page(s) matching the search query.`
     );
 };
-const _displayNextItem = (
+let _displayNextItem = (
   results,
   resultCount,
   searchTerms
@@ -179,8 +179,7 @@ const Search = {
     if (Search._queued_query !== null) {
       const query = Search._queued_query;
       Search._queued_query = null;
-      let { results, searchTerms, highlightTerms } = Search.query(query);
-      _displayNextItem(results, results.length, searchTerms, highlightTerms);
+      Search.query(query);
     }
   },
 
@@ -228,12 +227,8 @@ const Search = {
     Search.startPulse();
 
     // index already loaded, the browser was quick!
-    if (Search.hasIndex()) { 
-      let { results, searchTerms, highlightTerms } = Search.query(query);
-      _displayNextItem(results, results.length, searchTerms, highlightTerms);
-    } else {
-      Search.deferQuery(query);
-    }
+    if (Search.hasIndex()) Search.query(query);
+    else Search.deferQuery(query);
   },
 
   /**
@@ -365,7 +360,8 @@ const Search = {
     //Search.lastresults = results.slice();  // a copy
     // console.info("search results:", Search.lastresults);
 
-    return { results, searchTerms, highlightTerms };
+    // print the results
+    _displayNextItem(results, results.length, searchTerms);
   },
 
   /**

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -285,10 +285,12 @@ const Search = {
       if (title.toLowerCase().includes(queryLower) && (queryLower.length >= title.length/2)) {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
+          let isDocumentTitle = titles[file] === title
+          let sectionId = id ? "#" + id : ""
           results.push([
             docNames[file],
-            titles[file] !== title ? `${titles[file]} > ${title}` : title,
-            id !== null ? "#" + id : "",
+            isDocumentTitle ? title : `${titles[file]} > ${title}`,
+            isDocumentTitle ? "" : sectionId, // don't use the section id if we matched on the exact document title (creates duplicates below)
             null,
             score,
             filenames[file],
@@ -343,14 +345,12 @@ const Search = {
 
     // remove duplicate search results
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
-    // this may remove some entries which refer to slightly different parts of the same document
-    // but this is a tradeoff to avoid showing the same document multiple times (the preview always looks the
-    // same, so this is not very useful)
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      if (!seen.has(result[0])) {
+      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      if (!seen.has(resultStr)) {
         acc.push(result);
-        seen.add(result[0]);
+        seen.add(resultStr);
       }
       return acc;
     }, []);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -288,7 +288,7 @@ const Search = {
           results.push([
             docNames[file],
             titles[file] !== title ? `${titles[file]} > ${title}` : title,
-            id !== null ? "#" + id : "",
+            titles[file] !== title && id !== null ? "#" + id : "",
             null,
             score,
             filenames[file],

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -350,8 +350,8 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      const [docName, _title, anchor, _descr, _score, _filename] = result;
-      const resultStr = `${docName}${anchor}`;
+      const [docName, _title, anchor, descr, _score, filename] = result;
+      const resultStr = `${docName},${anchor},${descr},${filename}`;
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -179,7 +179,8 @@ const Search = {
     if (Search._queued_query !== null) {
       const query = Search._queued_query;
       Search._queued_query = null;
-      Search.query(query);
+      let { results, searchTerms, highlightTerms } = Search.query(query);
+      _displayNextItem(results, results.length, searchTerms, highlightTerms);
     }
   },
 
@@ -227,8 +228,12 @@ const Search = {
     Search.startPulse();
 
     // index already loaded, the browser was quick!
-    if (Search.hasIndex()) Search.query(query);
-    else Search.deferQuery(query);
+    if (Search.hasIndex()) { 
+      let { results, searchTerms, highlightTerms } = Search.query(query);
+      _displayNextItem(results, results.length, searchTerms, highlightTerms);
+    } else {
+      Search.deferQuery(query);
+    }
   },
 
   /**
@@ -361,8 +366,7 @@ const Search = {
     //Search.lastresults = results.slice();  // a copy
     // console.info("search results:", Search.lastresults);
 
-    // print the results
-    _displayNextItem(results, results.length, searchTerms);
+    return { results, searchTerms, highlightTerms };
   },
 
   /**
@@ -457,17 +461,23 @@ const Search = {
         { files: terms[word], score: Scorer.term },
         { files: titleTerms[word], score: Scorer.title },
       ];
+
       // add support for partial matches
       if (word.length > 2) {
         const escapedWord = _escapeRegExp(word);
-        Object.keys(terms).forEach((term) => {
-          if (term.match(escapedWord) && !terms[word])
-            arr.push({ files: terms[term], score: Scorer.partialTerm });
-        });
-        Object.keys(titleTerms).forEach((term) => {
-          if (term.match(escapedWord) && !titleTerms[word])
-            arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
-        });
+        if (!terms.hasOwnProperty(word)) {
+          Object.keys(terms).forEach((term) => {
+            if (term.match(escapedWord)) {
+              arr.push({ files: terms[term], score: Scorer.partialTerm });
+            }
+          });
+        }
+        if (!titleTerms.hasOwnProperty(word)) {
+          Object.keys(titleTerms).forEach((term) => {
+            if (term.match(escapedWord))
+              arr.push({ files: titleTerms[word], score: Scorer.partialTitle });
+          });
+        }
       }
 
       // no match but word was a required one
@@ -490,9 +500,13 @@ const Search = {
 
       // create the mapping
       files.forEach((file) => {
-        if (fileMap.has(file) && fileMap.get(file).indexOf(word) === -1)
-          fileMap.get(file).push(word);
-        else fileMap.set(file, [word]);
+        if (fileMap.has(file)) {
+          if (fileMap.get(file).indexOf(word) === -1) {
+            fileMap.get(file).push(word);
+          }
+        } else {
+          fileMap.set(file, [word]);
+        }
       });
     });
 

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -295,7 +295,7 @@ const Search = {
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
-            isDocumentTitle ? "" : anchor, // don't provide an anchor if we matched on the exact document title (creates duplicates below)
+            anchor,
             null,
             score,
             filenames[file],
@@ -352,7 +352,8 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      // de-duplicate on file, title, and description
+      let resultStr = result.slice(0, 2).concat(result[3]).map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -64,7 +64,7 @@ const _displayItem = (item, searchTerms) => {
   const docLinkSuffix = DOCUMENTATION_OPTIONS.LINK_SUFFIX;
   const showSearchSummary = DOCUMENTATION_OPTIONS.SHOW_SEARCH_SUMMARY;
 
-  const [docName, title, anchor, descr, score, _filename] = item;
+  const [docName, title, _isDocumentTitle, anchor, descr, score] = item;
 
   let listItem = document.createElement("li");
   let requestUrl;
@@ -295,6 +295,7 @@ const Search = {
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
+            isDocumentTitle,
             anchor,
             null,
             score,
@@ -312,6 +313,7 @@ const Search = {
           results.push([
             docNames[file],
             titles[file],
+            false,
             id ? "#" + id : "",
             null,
             score,
@@ -336,8 +338,8 @@ const Search = {
     // display function below uses pop() to retrieve items) and then
     // alphabetically
     results.sort((a, b) => {
-      const leftScore = a[4];
-      const rightScore = b[4];
+      const leftScore = a[5];
+      const rightScore = b[5];
       if (leftScore === rightScore) {
         // same score: sort alphabetically
         const leftTitle = a[1].toLowerCase();
@@ -352,8 +354,11 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      // de-duplicate on file, title, and description
-      let resultStr = result.slice(0, 2).concat(result[3]).map(v => String(v)).join(',');
+      // de-duplicate on file, title, description, and (if not the title section) anchor
+      // we omit the anchor for the title section as otherwise we'll get two entries for the
+      // entire document
+      let [docname, title, isDocumentTitle, anchor, descr, score, filename] = result;
+      let resultStr = [docname, title, isDocumentTitle ? '' : anchor, descr].map(v => String(v)).join(',');
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);
@@ -427,6 +432,7 @@ const Search = {
       results.push([
         docNames[match[0]],
         fullname,
+        false,
         "#" + anchor,
         descr,
         score,
@@ -544,6 +550,7 @@ const Search = {
       results.push([
         docNames[file],
         titles[file],
+        false,
         "",
         null,
         score,

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -350,7 +350,8 @@ const Search = {
     // note the reversing of results, so that in the case of duplicates, the highest-scoring entry is kept
     let seen = new Set();
     results = results.reverse().reduce((acc, result) => {
-      let resultStr = result.slice(0, 4).concat([result[5]]).map(v => String(v)).join(',');
+      const [docName, _title, anchor, _descr, _score, _filename] = result;
+      const resultStr = `${docName}${anchor}`;
       if (!seen.has(resultStr)) {
         acc.push(result);
         seen.add(resultStr);

--- a/sphinx/themes/basic/static/searchtools.js
+++ b/sphinx/themes/basic/static/searchtools.js
@@ -286,11 +286,11 @@ const Search = {
         for (const [file, id] of foundTitles) {
           let score = Math.round(100 * queryLower.length / title.length)
           let isDocumentTitle = titles[file] === title
-          let sectionId = id ? "#" + id : ""
+          let anchor = id ? `#${id}` : ""
           results.push([
             docNames[file],
             isDocumentTitle ? title : `${titles[file]} > ${title}`,
-            isDocumentTitle ? "" : sectionId, // don't use the section id if we matched on the exact document title (creates duplicates below)
+            isDocumentTitle ? "" : anchor, // don't provide an anchor if we matched on the exact document title (creates duplicates below)
             null,
             score,
             filenames[file],

--- a/tests/js/documentation_options.js
+++ b/tests/js/documentation_options.js
@@ -1,1 +1,9 @@
 const DOCUMENTATION_OPTIONS = {};
+
+// stub Stemmer / stopWords
+function Stemmer() {
+    this.stemWord = function (word) {
+        return word;
+    }
+};
+let stopwords = [];

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -19,7 +19,6 @@ describe('Basic html theme search', function() {
       hits = [[
         "index",
         "&lt;no title&gt;",
-        false,
         "",
         null,
         5,
@@ -50,7 +49,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', true, '#main-page', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
       ]);
     });
   })

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -19,6 +19,7 @@ describe('Basic html theme search', function() {
       hits = [[
         "index",
         "&lt;no title&gt;",
+        false,
         "",
         null,
         5,
@@ -49,7 +50,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', true, '#main-page', null, 100, 'index.rst' ],
       ]);
     });
   })

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -33,17 +33,17 @@ describe('Basic html theme search', function() {
     it("should not duplicate on title and content", function() {
       index = {
         alltitles: {
-          'Main Page': [[0, 'main-page']],
+          'Main Page': [[1, 'main-page']],
         },
-        docnames:["index"],
-        filenames:["index.rst"],
+        docnames:["", "index"],
+        filenames:["", "index.rst"],
         indexentries:{},
         objects:{},
         objtypes: {},
         objnames: {},
-        terms:{main:0, page:0},
-        titles:["Main Page"],
-        titleterms:{ main:0, page:0 }
+        terms:{main:1, page:1},
+        titles:["", "Main Page"],
+        titleterms:{ main:1, page:1 }
       }
       Search.setIndex(index);
 

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -21,13 +21,38 @@ describe('Basic html theme search', function() {
         "&lt;no title&gt;",
         "",
         null,
-        2,
+        5,
         "index.rst"
       ]];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);
     });
 
   });
+
+  describe('query', function() {
+    it("should not duplicate on title and content", function() {
+      index = {
+        alltitles: {
+          'Main Page': [[0, 'main-page']],
+        },
+        docnames:["index"],
+        filenames:["index.rst"],
+        indexentries:{},
+        objects:{},
+        objtypes: {},
+        objnames: {},
+        terms:{main:0, page:0},
+        titles:["Main Page"],
+        titleterms:{ main:0, page:0 }
+      }
+      Search.setIndex(index);
+      let { results } = Search.query('main page');
+      // should only be one result
+      expect(results).toEqual([
+        [ 'index', 'Main Page', '', null, 100, 'index.rst' ],
+      ]);
+    });
+  })
 
 });
 

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -49,7 +49,7 @@ describe('Basic html theme search', function() {
       let { results } = Search.query('main page');
       // should only be one result
       expect(results).toEqual([
-        [ 'index', 'Main Page', '', null, 100, 'index.rst' ],
+        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
       ]);
     });
   })

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -21,7 +21,7 @@ describe('Basic html theme search', function() {
         "&lt;no title&gt;",
         "",
         null,
-        5,
+        2,
         "index.rst"
       ]];
       expect(Search.performTermsSearch(searchterms, excluded, terms, titleterms)).toEqual(hits);

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -47,7 +47,7 @@ describe('Basic html theme search', function() {
       }
       Search.setIndex(index);
 
-      _displayNextItem = jasmine.createSpy().and.returnValue(null);
+      _displayNextItem = jasmine.createSpy();
       Search.query('main page');
 
       // should only be one result

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -46,11 +46,16 @@ describe('Basic html theme search', function() {
         titleterms:{ main:0, page:0 }
       }
       Search.setIndex(index);
-      let { results } = Search.query('main page');
+
+      _displayNextItem = jasmine.createSpy().and.returnValue(null);
+      Search.query('main page');
+
       // should only be one result
-      expect(results).toEqual([
-        [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ],
-      ]);
+      expect(_displayNextItem).toHaveBeenCalledWith(
+        [ [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ] ],
+        1,
+        new Set([ 'main', 'page' ])
+      );
     });
   })
 

--- a/tests/js/searchtools.js
+++ b/tests/js/searchtools.js
@@ -52,7 +52,7 @@ describe('Basic html theme search', function() {
 
       // should only be one result
       expect(_displayNextItem).toHaveBeenCalledWith(
-        [ [ 'index', 'Main Page', '#main-page', null, 100, 'index.rst' ] ],
+        [ [ 'index', 'Main Page', '', null, 100, 'index.rst' ] ],
         1,
         new Set([ 'main', 'page' ])
       );


### PR DESCRIPTION
### Feature or Bugfix
- N/A - discussion pull request.

### Purpose
- This pull request is to help describe an alternative approach I'd been thinking about while reviewing sphinx-doc/sphinx#11942.

### Detail
- Drop the `title` field from the search result de-duplication key (`resultStr`).

### Relates
- N/A